### PR TITLE
fix: assign user-extended configs to primary configs

### DIFF
--- a/lua/plugins/list.lua
+++ b/lua/plugins/list.lua
@@ -446,10 +446,10 @@ if util.is_present('cargo') then
     table.insert(lsp_servers, 'rust_analyzer')
 end
 
-vim.tbl_extend('force', plugins, util.get_user_config('user_plugins', {}))
-vim.tbl_extend('force', lsp_servers, util.get_user_config('user_lsp_servers', {}))
-vim.tbl_extend('force', null_ls_sources, util.get_user_config('user_null_ls_sources', {}))
-vim.tbl_extend('force', treesitter_parsers, util.get_user_config('user_tresitter_parsers', {}))
+plugins = vim.tbl_extend('force', plugins, util.get_user_config('user_plugins', {}))
+lsp_servers = vim.tbl_extend('force', lsp_servers, util.get_user_config('user_lsp_servers', {}))
+null_ls_sources = vim.tbl_extend('force', null_ls_sources, util.get_user_config('user_null_ls_sources', {}))
+treesitter_parsers = vim.tbl_extend('force', treesitter_parsers, util.get_user_config('user_tresitter_parsers', {}))
 
 return {
     plugins = plugins,


### PR DESCRIPTION
## What does the PR do? (Required)

This change ensures that the user configs actually extend the main configs. `vim.tbl_extend` doesn't modify tables in-place, so we need to actually use the returned table instead. I imagine you could probably use `vim.list_extend` too.

## Checklist (Required)

- [x] I have tested the changes on my local machine
- [x] I have added relevant documentation and tests for the changes
- [x] I have followed the style guidelines of this project

## Evidence (Required)

I think this change is self-explanatory.